### PR TITLE
Update speech.ts to fix model_id

### DIFF
--- a/nodes/ElevenLabs/resources/speech.ts
+++ b/nodes/ElevenLabs/resources/speech.ts
@@ -174,7 +174,7 @@ export const SpeechOperations: INodeProperties[] = [
 				typeOptions: {
 					loadOptionsMethod: 'listModels',
 				},
-				default: '',
+				default: 'eleven_multilingual_v2',
 			},
 			// stability
 			{
@@ -273,6 +273,7 @@ async function preSendText(
 
 	const data: any = {
 		text: text,
+		model_id: model_id,
 		voice_settings: {
 			stability: stability,
 			similarity_boost: similarity_boost,


### PR DESCRIPTION
Currently the model id is not taken into account leading to the eleven_monolingual_v1 being used no matter what's set up. ([see this issue](https://github.com/n8n-ninja/n8n-nodes-elevenlabs/issues/3))

I've included the model_id in the data and also updated the default to be the multilingual eleven_multilingual_v2 to make it easier for beginer.

Best,