### PR TITLE
Add support to enforce language

### DIFF
--- a/nodes/ElevenLabs/resources/speech.ts
+++ b/nodes/ElevenLabs/resources/speech.ts
@@ -240,6 +240,15 @@ export const SpeechOperations: INodeProperties[] = [
 				type: 'boolean',
 				default: true,
 			},
+			// language_id
+			{
+				displayName: 'Language',
+				description:
+					'Enforce model to produce audio in a specific language. If not set, the model will use the language of the input text.',
+				name: 'language_id',
+				type: 'string',
+				default: '',
+			},
 		],
 	},
 ];
@@ -270,6 +279,7 @@ async function preSendText(
 	const style = this.getNodeParameter('additionalFields.style', 0);
 	const use_speaker_boost = this.getNodeParameter('additionalFields.use_speaker_boost', true);
 	const stitching = this.getNodeParameter('additionalFields.stitching', false);
+	const language_id = this.getNodeParameter('additionalFields.language', '');
 
 	const data: any = {
 		text: text,
@@ -281,6 +291,10 @@ async function preSendText(
 			use_speaker_boost: use_speaker_boost,
 		},
 	};
+
+	if (language_id !== '') {
+		data.language_id = language_id;
+	}
 
 	// Stitching
 	if (stitching) {


### PR DESCRIPTION
The documentation mentions the field `language_code` but it might be deprecated in favour of `language_id` which receives a language in ISO 639-1 (eg: en, pt, es...).
<img width="891" alt="Screenshot 2024-08-29 at 01 47 22" src="https://github.com/user-attachments/assets/2a20eee7-4577-4889-9a25-889716269c58">
